### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/dashinja/b3c73c82-f00d-420f-991a-08d977db15e1/e8417f03-952f-4b4d-aaad-902d56839ed5/_apis/work/boardbadge/d0a5c263-c395-47fd-a952-d6a4d7238529)](https://dev.azure.com/dashinja/b3c73c82-f00d-420f-991a-08d977db15e1/_boards/board/t/e8417f03-952f-4b4d-aaad-902d56839ed5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dashinja/b3c73c82-f00d-420f-991a-08d977db15e1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.